### PR TITLE
Add `bfsFile`.

### DIFF
--- a/src/Yesod/Form/Bootstrap4.hs
+++ b/src/Yesod/Form/Bootstrap4.hs
@@ -11,6 +11,7 @@ module Yesod.Form.Bootstrap4
   , BootstrapFormLayout(..)
   , BootstrapGridOptions(..)
   , bfs
+  , bfsFile
   , withPlaceholder
   , withAutofocus
   , withLargeInput
@@ -29,7 +30,14 @@ import           Yesod.Core    (HandlerSite, MonadHandler, RenderMessage,
 import           Yesod.Form
 
 bfs :: RenderMessage site msg => msg -> FieldSettings site
-bfs msg = FieldSettings (SomeMessage msg) Nothing Nothing Nothing [("class", "form-control")]
+bfs = bfsFileOrNo False
+
+bfsFile :: RenderMessage site msg => msg -> FieldSettings site
+bfsFile = bfsFileOrNo True
+
+bfsFileOrNo :: RenderMessage site msg => Bool -> msg -> FieldSettings site
+bfsFileOrNo isFile msg = FieldSettings (SomeMessage msg) Nothing Nothing Nothing [("class", classVal)]
+  where classVal = if isFile then "form-control-file" else "form-control"
 
 withPlaceholder :: Text -> FieldSettings site -> FieldSettings site
 withPlaceholder placeholder fs = fs { fsAttrs = newAttrs }

--- a/src/Yesod/Form/Bootstrap4.hs
+++ b/src/Yesod/Form/Bootstrap4.hs
@@ -30,14 +30,12 @@ import           Yesod.Core    (HandlerSite, MonadHandler, RenderMessage,
 import           Yesod.Form
 
 bfs :: RenderMessage site msg => msg -> FieldSettings site
-bfs = bfsFileOrNo False
+bfs msg
+  = FieldSettings (SomeMessage msg) Nothing Nothing Nothing [("class", "form-control")]
 
 bfsFile :: RenderMessage site msg => msg -> FieldSettings site
-bfsFile = bfsFileOrNo True
-
-bfsFileOrNo :: RenderMessage site msg => Bool -> msg -> FieldSettings site
-bfsFileOrNo isFile msg = FieldSettings (SomeMessage msg) Nothing Nothing Nothing [("class", classVal)]
-  where classVal = if isFile then "form-control-file" else "form-control"
+bfsFile msg
+  = FieldSettings (SomeMessage msg) Nothing Nothing Nothing [("class", "form-control-file")]
 
 withPlaceholder :: Text -> FieldSettings site -> FieldSettings site
 withPlaceholder placeholder fs = fs { fsAttrs = newAttrs }


### PR DESCRIPTION
`bfsFile` is a function that creates a proper BootStrap 4 input for file
controls. The only difference between `bfsFile` and `bfs` is the value
of the class attributes on the generated input element. For `bfsFile`,
this is "form-control-file", while for `bfs`, this is "form-control".